### PR TITLE
online readthedocs build failed due to free trial ended; add some con…

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -52,8 +52,9 @@ templates_path = ['_templates']
 
 # configuration for 'autoapi.extension'
 autoapi_type = 'python'
-autoapi_dirs = ['../../fedlab_core']
+autoapi_dirs = ['../../fedlab_core', '../../fedlab_utils']
 autoapi_template_dir = '_autoapi_templates'
+add_module_names = False  # makes Sphinx render package.module.Class as Class
 
 # Add more mapping for 'sphinx.ext.intersphinx'
 intersphinx_mapping = {'python': ('https://docs.python.org/3', None),


### PR DESCRIPTION
…fig for docs/source/conf.py to ignore parent module name for some classes