### PR TITLE
Fixed Network Connection Checker fedlabimport error

### DIFF
--- a/examples/network-connection-checker/client.py
+++ b/examples/network-connection-checker/client.py
@@ -1,5 +1,7 @@
 
 import argparse
+import sys
+sys.path.append("../../")
 from fedlab.core.network import DistNetwork
 
 

--- a/examples/network-connection-checker/server.py
+++ b/examples/network-connection-checker/server.py
@@ -1,5 +1,7 @@
 
 import argparse
+import sys
+sys.path.append("../../")
 from fedlab.core.network import DistNetwork
 
 parser = argparse.ArgumentParser(description="Network connection checker")


### PR DESCRIPTION
When running network -connection-checker `server.py` it threw error.

` C:\Projects\FedLab\examples\network-connection-checker> python.exe .\server.py --ip 130.149.248.247 --port 12345 --world_size 3 --ethernet "eth0"      
Traceback (most recent call last):
  File ".\server.py", line 3, in <module>
    from fedlab.core.network import DistNetwork
ModuleNotFoundError: No module named 'fedlab'`

fixed it by appending path.