### PR TITLE
Fix Scaffold

### DIFF
--- a/fedlab/contrib/algorithm/scaffold.py
+++ b/fedlab/contrib/algorithm/scaffold.py
@@ -19,8 +19,7 @@ class ScaffoldServerHandler(SyncServerHandler):
 
     def setup_optim(self, lr):
         self.lr = lr
-        # self.global_c = torch.zeros_like(self.model_parameters)
-        self.global_c = torch.zeros_like(self.model_grad_parameters)
+        self.global_c = torch.zeros_like(self.model_parameters)
 
     def global_update(self, buffer):
         # unpack
@@ -79,10 +78,10 @@ class ScaffoldSerialClientTrainer(SGDSerialClientTrainer):
                 grad = self.model_grads
                 grad = grad - self.cs[id] + global_c
                 idx = 0
-
+                
                 parameters = self._model.parameters()
                 for p in self._model.state_dict().values():
-                    if p.grad is None: # batchnorm have no grad
+                    if p.grad is None: # Batchnorm have no grad
                         layer_size = p.numel()
                     else:
                         parameter = next(parameters)
@@ -97,11 +96,11 @@ class ScaffoldSerialClientTrainer(SGDSerialClientTrainer):
                 #     #parameter.grad = parameter.grad - self.cs[id][idx:idx + layer_size].view(parameter.grad.shape) + global_c[idx:idx + layer_size].view(parameter.grad.shape)
                 #     parameter.grad.data[:] = grad[idx:idx+layer_size].view(shape)[:]
                 #     idx += layer_size
-                # print(idx)
 
                 self.optimizer.step()
 
         dy = self.model_parameters - frz_model
-        dc = -1.0 / (self.epochs * len(train_loader) * self.lr) * dy - global_c  # ????
+        dc = -1.0 / (self.epochs * len(train_loader) * self.lr) * dy - global_c
         self.cs[id] += dc
         return [dy, dc]
+        

--- a/fedlab/contrib/algorithm/scaffold.py
+++ b/fedlab/contrib/algorithm/scaffold.py
@@ -19,7 +19,8 @@ class ScaffoldServerHandler(SyncServerHandler):
 
     def setup_optim(self, lr):
         self.lr = lr
-        self.global_c = torch.zeros_like(self.model_parameters)
+        # self.global_c = torch.zeros_like(self.model_parameters)
+        self.global_c = torch.zeros_like(self.model_grad_parameters)
 
     def global_update(self, buffer):
         # unpack
@@ -74,19 +75,33 @@ class ScaffoldSerialClientTrainer(SGDSerialClientTrainer):
                 self.optimizer.zero_grad()
                 loss.backward()
 
-                grad = self.model_gradients
+                # grad = self.model_gradients
+                grad = self.model_grads
                 grad = grad - self.cs[id] + global_c
                 idx = 0
-                for parameter in self._model.parameters():
-                    layer_size = parameter.grad.numel()
-                    shape = parameter.grad.shape
-                    #parameter.grad = parameter.grad - self.cs[id][idx:idx + layer_size].view(parameter.grad.shape) + global_c[idx:idx + layer_size].view(parameter.grad.shape)
-                    parameter.grad.data[:] = grad[idx:idx+layer_size].view(shape)[:]
+
+                parameters = self._model.parameters()
+                for p in self._model.state_dict().values():
+                    if p.grad is None: # batchnorm have no grad
+                        layer_size = p.numel()
+                    else:
+                        parameter = next(parameters)
+                        layer_size = parameter.data.numel()
+                        shape = parameter.grad.shape
+                        parameter.grad.data[:] = grad[idx:idx+layer_size].view(shape)[:]
                     idx += layer_size
+
+                # for parameter in self._model.parameters():
+                #     layer_size = parameter.grad.numel()
+                #     shape = parameter.grad.shape
+                #     #parameter.grad = parameter.grad - self.cs[id][idx:idx + layer_size].view(parameter.grad.shape) + global_c[idx:idx + layer_size].view(parameter.grad.shape)
+                #     parameter.grad.data[:] = grad[idx:idx+layer_size].view(shape)[:]
+                #     idx += layer_size
+                # print(idx)
 
                 self.optimizer.step()
 
         dy = self.model_parameters - frz_model
-        dc = -1.0 / (self.epochs * len(train_loader) * self.lr) * dy - global_c
+        dc = -1.0 / (self.epochs * len(train_loader) * self.lr) * dy - global_c  # ????
         self.cs[id] += dc
         return [dy, dc]

--- a/fedlab/core/model_maintainer.py
+++ b/fedlab/core/model_maintainer.py
@@ -61,6 +61,20 @@ class ModelMaintainer(object):
         return SerializationTool.serialize_model(self._model)
 
     @property
+    def model_grads(self) -> torch.Tensor: 
+        """Return serialized model gradients(base on model.state_dict(), Shape is the same as model_parameters)."""
+        params = self._model.state_dict()
+        for name, p in self._model.named_parameters():
+            params[name].grad = p.grad
+        for key in params:
+            if params[key].grad is None:
+                params[key].grad = torch.zeros_like(params[key])
+        gradients = [param.grad.data.view(-1) for param in params.values()]
+        m_gradients = torch.cat(gradients)
+        m_gradients = m_gradients.cpu()
+        return m_gradients
+
+    @property
     def model_gradients(self) -> torch.Tensor:
         """Return serialized model gradients."""
         return SerializationTool.serialize_model_gradients(self._model)


### PR DESCRIPTION
Batchnorm层 的参数没有梯度，self.model_parameters 和 self.model_gradients 的 长度不一样

重新实现一个model_grads()， 根据named_parameters()得到state_dict()形状的参数梯度，没有梯度的参数 的 梯度设为0